### PR TITLE
Translations update from Foundry Hub - Weblate

### DIFF
--- a/languages/pl.json
+++ b/languages/pl.json
@@ -3,6 +3,13 @@
 		"unlocked": "Nic nie wstrzymuje cię od mówienia jako ta postać.",
 		"locked": "{module} wstrzymuje cię od mówienia jako ta postać.",
 		"self-locked": "Zablokowałeś/aś się, by mówić poza tą postacią.",
-		"buttonHint": "Kliknij, aby mówić poza postacią przez następną wiadomość. Kliknij dwukrotnie, aby to robić aż do ponownego kliknięcia."
+		"buttonHint": "Kliknij, aby mówić poza postacią przez następną wiadomość. Kliknij dwukrotnie, aby to robić aż do ponownego kliknięcia.",
+		"warning": "Używasz zastrzeżonych ({characters}) liter podczas mówienia poza postacią! Czy chciałeś zamiast tego mówić w charakterze?",
+		"settings": {
+			"warningCharacters": {
+				"name": "Ostrzeżenie w przypadku wypowiadania znaków specjalnych",
+				"hint": "Podświetla okno czatu, jeśli używasz zastrzeżonych znaków, takich jak \"cudzysłowy\" lub innych wybranych znaków podczas mówienia poza postacią. Jeśli ustawienie jest puste, ostrzeżenia nie będą wyświetlane. Używa Regex."
+			}
+		}
 	}
 }


### PR DESCRIPTION
Translations update from [Foundry Hub - Weblate](https://weblate.foundryvtt-hub.com) for [Speaking As/main](https://weblate.foundryvtt-hub.com/projects/speaking-as/main/).



Current translation status:

![Weblate translation status](https://weblate.foundryvtt-hub.com/widgets/speaking-as/-/main/horizontal-auto.svg)